### PR TITLE
Fix package.xml for rosdep install

### DIFF
--- a/LeGO-LOAM/package.xml
+++ b/LeGO-LOAM/package.xml
@@ -16,8 +16,8 @@
   <run_depend>roscpp</run_depend>
   <build_depend>rospy</build_depend>
   <run_depend>rospy</run_depend>
-  <build_depend>ros_bridge</build_depend>
-  <run_depend>ros_bridge</run_depend>
+  <build_depend>rosbridge_suite</build_depend>
+  <run_depend>rosbridge_suite</run_depend>
   
   <build_depend>tf</build_depend>
   <run_depend>tf</run_depend>
@@ -34,8 +34,8 @@
   <run_depend>std_msgs</run_depend>
   <build_depend>cloud_msgs</build_depend>
   <run_depend>cloud_msgs</run_depend>
-  <build_depend>sensors_msgs</build_depend>
-  <run_depend>sensors_msgs</run_depend>
+  <build_depend>sensor_msgs</build_depend>
+  <run_depend>sensor_msgs</run_depend>
   <build_depend>geometry_msgs</build_depend>
   <run_depend>geometry_msgs</run_depend>
   <build_depend>nav_msgs</build_depend>
@@ -44,7 +44,7 @@
   <build_depend>image_transport</build_depend>
   <run_depend>image_transport</run_depend>
   
-  <build_depend>gtsam</build_depend>
-  <run_depend>gtsam</run_depend>
+  <!--<build_depend>gtsam</build_depend>
+  <run_depend>gtsam</run_depend>-->
 
 </package>


### PR DESCRIPTION
When trying to install dependencies automatically via `rosdep install`, this package fails due to packages not being specified correctly according to the [`rosdistro` repository](https://github.com/ros/rosdistro). The package-strings for `rosbridge_suite` and `sensor_msgs` have therefore been updated accordingly.
As `gtsam` is not available in these sources, the dependecy has been commented out. Dependency checking for GTSAM, PCL and OpenCV is handled via the CMakeLists.txt anyway.